### PR TITLE
Only correct whole words

### DIFF
--- a/ocrfixr/spellcheck.py
+++ b/ocrfixr/spellcheck.py
@@ -200,7 +200,9 @@ class spellcheck:
         # otherwise, replace all dict entries with the approved replacement word
             text_corrected = self.text
             for i, j in fixes.items():
-                text_corrected = re.sub(re.escape(i), j, text_corrected)
+                # Only match and replace whole words
+                pattern = "\\b" + re.escape(i) + "\\b"
+                text_corrected = re.sub(pattern, j, text_corrected)
             return(text_corrected)
     
     


### PR DESCRIPTION
spellcheck._MULTI_REPLACE currently replaces all matches of a misread - not just whole words.

Example:
- If the misread is "bo" and the correction "to"
- And the text is the "boarding a flight bo London"
- The output would be: "toarding a flight to London"
- When it should be: "boarding a flight to London"

This pull request restricts corrections to whole word matches.